### PR TITLE
fix(example/macos): allow running on flutter stable

### DIFF
--- a/packages/liquid_glass_renderer/example/macos/Runner/Info.plist
+++ b/packages/liquid_glass_renderer/example/macos/Runner/Info.plist
@@ -28,5 +28,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>FLTEnableImpeller</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

When running macos example on flutter stable (3.32.8) without `--enable-impeller` flag, the app shows red ErrorWidget and prints
```
======== Exception caught by widgets library =======================================================
The following assertion was thrown building Glassify(dirty, state: _GlassifyState#<...>):
liquid_glass_renderer is only supported when using Impeller at the moment. Please enable Impeller, or check ImageFilter.isShaderFilterSupported before you use liquid glass widgets.
'package:liquid_glass_renderer/src/glassify.dart':
Failed assertion: line 59 pos 9: 'ImageFilter.isShaderFilterSupported'
```

```
======== Exception caught by widgets library =======================================================
The following assertion was thrown building LiquidGlassLayer(dirty, state: _LiquidGlassLayerState#<...>):
liquid_glass_renderer is only supported when using Impeller at the moment. Please enable Impeller, or check ImageFilter.isShaderFilterSupported before you use liquid glass widgets.
'package:liquid_glass_renderer/src/liquid_glass_layer.dart':
Failed assertion: line 83 pos 9: 'ImageFilter.isShaderFilterSupported'
```

so I just enabled impeller in Info.plist, now no command line flags are needed

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [ ] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation) -- no API changes
- [ ] I have added tests to cover my changes -- no functionality added to test
