### PR TITLE
Fix glass scaling

### DIFF
--- a/packages/liquid_glass_renderer/example/lib/clock.dart
+++ b/packages/liquid_glass_renderer/example/lib/clock.dart
@@ -42,21 +42,19 @@ class ClockExample extends HookWidget {
         ).show(context);
       },
       child: ImagePageView(
-        child: Center(
-          child: FittedBox(
-            fit: BoxFit.contain,
-            child: LiquidGlass(
-              settings: settings.copyWith(glassColor: Colors.transparent),
-              shape: LiquidRoundedRectangle(borderRadius: Radius.circular(64)),
-              child: Padding(
-                padding: const EdgeInsets.all(64.0),
-                child: Glassify(
-                  settings: settings,
-                  child: Text(
-                    format.format(time),
-                    style: GoogleFonts.lexendGigaTextTheme().headlineLarge!
-                        .copyWith(fontSize: 200),
-                  ),
+        child: FittedBox(
+          fit: BoxFit.contain,
+          child: LiquidGlass(
+            settings: settings.copyWith(glassColor: Colors.transparent),
+            shape: LiquidRoundedRectangle(borderRadius: Radius.circular(64)),
+            child: Padding(
+              padding: const EdgeInsets.all(64.0),
+              child: Glassify(
+                settings: settings,
+                child: Text(
+                  format.format(time),
+                  style: GoogleFonts.lexendGigaTextTheme().headlineLarge!
+                      .copyWith(fontSize: 200),
                 ),
               ),
             ),

--- a/packages/liquid_glass_renderer/example/lib/shapes.dart
+++ b/packages/liquid_glass_renderer/example/lib/shapes.dart
@@ -29,13 +29,16 @@ class ShapesExample extends HookWidget {
         ).show(context);
       },
       child: ImagePageView(
-        child: Center(
+        child: FittedBox(
           child: Padding(
             padding: const EdgeInsets.all(32.0),
             child: LiquidGlassLayer(
               settings: settings,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
+              child: Flex(
+                direction: switch (MediaQuery.orientationOf(context)) {
+                  Orientation.portrait => Axis.vertical,
+                  Orientation.landscape => Axis.horizontal,
+                },
                 spacing: 64,
                 children: [
                   LiquidGlass.inLayer(

--- a/packages/liquid_glass_renderer/example/lib/shared.dart
+++ b/packages/liquid_glass_renderer/example/lib/shared.dart
@@ -4,7 +4,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:liquid_glass_renderer/liquid_glass_renderer.dart';
-import 'package:smooth_sheets/smooth_sheets.dart';
 
 Animation<double> useRotatingAnimationController() {
   return useAnimationController(
@@ -65,6 +64,7 @@ class ImagePageView extends HookWidget {
   @override
   Widget build(BuildContext context) {
     return Stack(
+      fit: StackFit.expand,
       children: [
         PageView.builder(
           itemBuilder: (context, index) {
@@ -101,11 +101,18 @@ class SettingsSheet extends HookWidget {
   Future<void> show(BuildContext context) {
     return Navigator.push(
       context,
-      ModalSheetRoute(
+      PageRouteBuilder(
+        opaque: false,
+        barrierDismissible: true,
+        transitionDuration: Duration.zero,
+        reverseTransitionDuration: Duration.zero,
+        pageBuilder: (_, __, ___) {
+          return GestureDetector(
+            onTap: () => Navigator.pop(context),
+            child: this,
+          );
+        },
         barrierColor: Colors.black26,
-        swipeDismissible: true,
-        viewportPadding: const EdgeInsets.all(100),
-        builder: (context) => this,
       ),
     );
   }
@@ -115,33 +122,28 @@ class SettingsSheet extends HookWidget {
     final settings = useValueListenable(settingsNotifier);
     final lightAngle = useValueListenable(lightAngleAnimation);
 
-    return Sheet(
-      dragConfiguration: SheetDragConfiguration(),
-      scrollConfiguration: const SheetScrollConfiguration(),
-      initialOffset: SheetOffset(1),
-      shrinkChildToAvoidDynamicOverlap: true,
-      shrinkChildToAvoidStaticOverlap: true,
-      snapGrid: SheetSnapGrid(snaps: [SheetOffset(0.5), SheetOffset(1)]),
-      child: SafeArea(
-        child: LiquidGlass(
-          glassContainsChild: false,
-          settings: LiquidGlassSettings(
-            thickness: 30,
-            blur: 20,
-            lightIntensity: .5,
-            lightAngle: lightAngle,
-            ambientStrength: .5,
-            chromaticAberration: 2,
-            glassColor: Theme.of(
-              context,
-            ).colorScheme.surface.withValues(alpha: 0.4),
-          ),
-          shape: LiquidRoundedSuperellipse(borderRadius: Radius.circular(24)),
-          child: DefaultTextStyle(
-            style: Theme.of(context).textTheme.bodyLarge!,
-            child: Align(
-              alignment: Alignment.topCenter,
-              child: SingleChildScrollView(
+    return SingleChildScrollView(
+      child: Center(
+        child: Padding(
+          padding: EdgeInsets.all(16) + EdgeInsets.symmetric(vertical: 320),
+          child: SizedBox(
+            width: (MediaQuery.sizeOf(context).width / 2).clamp(320, 640),
+            child: LiquidGlass(
+              glassContainsChild: false,
+              settings: LiquidGlassSettings(
+                thickness: 30,
+                blur: 20,
+                lightIntensity: .5,
+                lightAngle: lightAngle,
+                ambientStrength: .5,
+                chromaticAberration: 2,
+                glassColor: Theme.of(
+                  context,
+                ).colorScheme.surface.withValues(alpha: 0.4),
+              ),
+              shape: LiquidRoundedSuperellipse(borderRadius: Radius.circular(24)),
+              child: DefaultTextStyle(
+                style: Theme.of(context).textTheme.bodyLarge!,
                 child: Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: Column(
@@ -155,7 +157,7 @@ class SettingsSheet extends HookWidget {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Text('Thickness:'),
+                          Expanded(child: Text('Thickness:')),
                           Text(settings.thickness.toStringAsFixed(2)),
                         ],
                       ),
@@ -172,7 +174,7 @@ class SettingsSheet extends HookWidget {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Text('Light Intensity:'),
+                          Expanded(child: Text('Light Intensity:')),
                           Text(settings.lightIntensity.toStringAsFixed(2)),
                         ],
                       ),
@@ -189,7 +191,7 @@ class SettingsSheet extends HookWidget {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Text('Ambient Strength:'),
+                          Expanded(child: Text('Ambient Strength:')),
                           Text(settings.ambientStrength.toStringAsFixed(2)),
                         ],
                       ),
@@ -206,7 +208,7 @@ class SettingsSheet extends HookWidget {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Text('Blur:'),
+                          Expanded(child: Text('Blur:')),
                           Text(settings.blur.toStringAsFixed(2)),
                         ],
                       ),
@@ -223,7 +225,7 @@ class SettingsSheet extends HookWidget {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Text('Liquid Factor™:'),
+                          Expanded(child: Text('Liquid Factor™:')),
                           Text(settings.blend.toStringAsFixed(2)),
                         ],
                       ),
@@ -240,7 +242,7 @@ class SettingsSheet extends HookWidget {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Text('Chromatic Aberration:'),
+                          Expanded(child: Text('Chromatic Aberration:')),
                           Text(settings.chromaticAberration.toStringAsFixed(2)),
                         ],
                       ),
@@ -257,7 +259,7 @@ class SettingsSheet extends HookWidget {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Text('Saturation:'),
+                          Expanded(child: Text('Saturation:')),
                           Text(settings.saturation.toStringAsFixed(2)),
                         ],
                       ),
@@ -274,7 +276,7 @@ class SettingsSheet extends HookWidget {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Text('Lightness:'),
+                          Expanded(child: Text('Lightness:')),
                           Text(settings.lightness.toStringAsFixed(2)),
                         ],
                       ),
@@ -291,7 +293,7 @@ class SettingsSheet extends HookWidget {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Text('Refractive Index:'),
+                          Expanded(child: Text('Refractive Index:')),
                           Text(settings.refractiveIndex.toStringAsFixed(2)),
                         ],
                       ),

--- a/packages/liquid_glass_renderer/lib/src/glassify.dart
+++ b/packages/liquid_glass_renderer/lib/src/glassify.dart
@@ -339,10 +339,14 @@ class _GlassifyShaderLayer extends OffsetLayer {
   }
 
   ui.Image _buildMaskImage([double? blur]) {
+    final bounds = offset & layerSize;
+    if (bounds.isEmpty) {
+      return _buildEmptyImage();
+    }
+
     final builder = ui.SceneBuilder();
     final transform =
         Matrix4.diagonal3Values(devicePixelRatio, devicePixelRatio, 1);
-    final bounds = offset & layerSize;
 
     builder.pushTransform(transform.storage);
     _addMaskToScene(builder, blur);
@@ -353,6 +357,8 @@ class _GlassifyShaderLayer extends OffsetLayer {
           (devicePixelRatio * bounds.height).floor(),
         );
   }
+
+  ui.Image _buildEmptyImage() => ui.SceneBuilder().build().toImageSync(1, 1);
 
   void _addMaskToScene(ui.SceneBuilder builder, [double? blur]) {
     final mask = firstChild;

--- a/packages/liquid_glass_renderer/lib/src/glassify.dart
+++ b/packages/liquid_glass_renderer/lib/src/glassify.dart
@@ -180,6 +180,9 @@ class RenderGlassify extends RenderProxyBox {
   void paint(PaintingContext context, Offset offset) {
     // Calculate global position for the shader
     var globalOffset = offset;
+    var layerSize = size;
+    double scaleX = 1;
+    double scaleY = 1;
     try {
       final transform = getTransformTo(null);
       final globalRect = MatrixUtils.transformRect(
@@ -187,6 +190,9 @@ class RenderGlassify extends RenderProxyBox {
         Offset.zero & size,
       );
       globalOffset = globalRect.topLeft;
+      layerSize = globalRect.size;
+      scaleX = transform.storage[0]; // m00
+      scaleY = transform.storage[5]; // m11
     } catch (e) {
       // Fallback to the provided offset if transform calculation fails
       debugPrint('Failed to calculate global transform for Glassify: $e');
@@ -198,7 +204,9 @@ class RenderGlassify extends RenderProxyBox {
       shader: _shader,
       settings: _settings,
       devicePixelRatio: _devicePixelRatio,
-      layerSize: size,
+      layerSize: layerSize,
+      scaleX: scaleX,
+      scaleY: scaleY,
     );
     layer!
       ..offset = offset
@@ -206,7 +214,9 @@ class RenderGlassify extends RenderProxyBox {
       ..shader = _shader
       ..settings = _settings
       ..devicePixelRatio = _devicePixelRatio
-      ..layerSize = size;
+      ..layerSize = layerSize
+      ..scaleX = scaleX
+      ..scaleY = scaleY;
     context.pushLayer(
       layer!,
       (context, offset) {
@@ -244,12 +254,16 @@ class _GlassifyShaderLayer extends OffsetLayer {
     required LiquidGlassSettings settings,
     required double devicePixelRatio,
     required Size layerSize,
+    required double scaleX,
+    required double scaleY,
     required super.offset,
     required Offset globalOffset,
   })  : _shader = shader,
         _settings = settings,
         _devicePixelRatio = devicePixelRatio,
         _layerSize = layerSize,
+        _scaleX = scaleX,
+        _scaleY = scaleY,
         _globalOffset = globalOffset;
 
   FragmentShader _shader;
@@ -289,6 +303,22 @@ class _GlassifyShaderLayer extends OffsetLayer {
   set globalOffset(Offset value) {
     if (_globalOffset == value) return;
     _globalOffset = value;
+    markNeedsAddToScene();
+  }
+
+  double _scaleX;
+  double get scaleX => _scaleX;
+  set scaleX(double v) {
+    if (_scaleX == v) return;
+    _scaleX = v;
+    markNeedsAddToScene();
+  }
+
+  double _scaleY;
+  double get scaleY => _scaleY;
+  set scaleY(double v) {
+    if (_scaleY == v) return;
+    _scaleY = v;
     markNeedsAddToScene();
   }
 
@@ -345,8 +375,11 @@ class _GlassifyShaderLayer extends OffsetLayer {
     }
 
     final builder = ui.SceneBuilder();
-    final transform =
-        Matrix4.diagonal3Values(devicePixelRatio, devicePixelRatio, 1);
+    final transform = Matrix4.diagonal3Values(
+      devicePixelRatio * scaleX,
+      devicePixelRatio * scaleY,
+      1,
+    );
 
     builder.pushTransform(transform.storage);
     _addMaskToScene(builder, blur);

--- a/packages/liquid_glass_renderer/lib/src/liquid_glass.dart
+++ b/packages/liquid_glass_renderer/lib/src/liquid_glass.dart
@@ -221,8 +221,16 @@ class RenderLiquidGlass extends RenderProxyBox {
     super.paint(context, offset);
   }
 
-  void paintBlur(PaintingContext context, Offset offset, double blur) {
+  void paintBlur(
+    PaintingContext context,
+    Offset offset, {
+    required double blur,
+    required double scaleX,
+    required double scaleY,
+  }) {
     if (blur <= 0) return;
+
+    final shape = this.shape.scaleXY(scaleX, scaleY);
 
     context.pushClipPath(
       true,

--- a/packages/liquid_glass_renderer/lib/src/liquid_glass_layer.dart
+++ b/packages/liquid_glass_renderer/lib/src/liquid_glass_layer.dart
@@ -265,6 +265,13 @@ class RenderLiquidGlassLayer extends RenderProxyBox {
 
   @override
   void paint(PaintingContext context, Offset offset) {
+    final transform = getTransformTo(null);
+    final globalRect =
+        MatrixUtils.transformRect(transform, Offset.zero & size);
+    final offset = globalRect.topLeft;
+    final scaleX = transform.storage[0]; // m00
+    final scaleY = transform.storage[5]; // m11
+
     final shapes = collectShapes();
 
     if (_settings.thickness <= 0) {
@@ -305,7 +312,7 @@ class RenderLiquidGlassLayer extends RenderProxyBox {
         ..setFloat(baseIndex + 5, shape.cornerRadius * _devicePixelRatio);
     }
 
-    _paintShapeBlurs(context, offset, shapes);
+    _paintShapeBlurs(context, offset, shapes, scaleX: scaleX, scaleY: scaleY);
 
     _paintShapeContents(context, offset, shapes, glassContainsChild: true);
 
@@ -359,11 +366,15 @@ class RenderLiquidGlassLayer extends RenderProxyBox {
   void _paintShapeBlurs(
     PaintingContext context,
     Offset offset,
-    List<(RenderLiquidGlass, RawShape)> shapes,
-  ) {
+    List<(RenderLiquidGlass, RawShape)> shapes, {
+    required double scaleX,
+    required double scaleY,
+  }) {
+    final scaleXY = Matrix4.diagonal3Values(scaleX, scaleY, 1);
+
     for (final (render, _) in shapes) {
       // Get the transform from the shape to this layer
-      final transform = render.getTransformTo(this);
+      final transform = render.getTransformTo(this).multiplied(scaleXY);
 
       // Apply the full transform to the painting context for blur
       context.pushTransform(
@@ -371,7 +382,13 @@ class RenderLiquidGlassLayer extends RenderProxyBox {
         offset,
         transform,
         (context, offset) {
-          render.paintBlur(context, offset, _settings.blur);
+          render.paintBlur(
+            context,
+            offset,
+            blur: _settings.blur,
+            scaleX: scaleX,
+            scaleY: scaleY,
+          );
         },
       );
     }

--- a/packages/liquid_glass_renderer/lib/src/liquid_shape.dart
+++ b/packages/liquid_glass_renderer/lib/src/liquid_shape.dart
@@ -31,6 +31,11 @@ sealed class LiquidShape extends OutlinedBorder with EquatableMixin {
   }
 
   @override
+  ShapeBorder scale(double t);
+
+  ShapeBorder scaleXY(double scaleX, double scaleY);
+
+  @override
   List<Object?> get props => [side];
 }
 
@@ -75,6 +80,14 @@ class LiquidRoundedSuperellipse extends LiquidShape {
   }
 
   @override
+  ShapeBorder scaleXY(double scaleX, double scaleY) {
+    return LiquidRoundedSuperellipse(
+      borderRadius: borderRadius.scaleXY(scaleX, scaleY),
+      side: side.scaleXY(scaleX, scaleY),
+    );
+  }
+
+  @override
   List<Object?> get props => [...super.props, borderRadius];
 }
 
@@ -99,6 +112,13 @@ class LiquidOval extends LiquidShape {
   ShapeBorder scale(double t) {
     return LiquidOval(
       side: side.scale(t),
+    );
+  }
+
+  @override
+  ShapeBorder scaleXY(double scaleX, double scaleY) {
+    return LiquidOval(
+      side: side.scaleXY(scaleX, scaleY),
     );
   }
 }
@@ -145,5 +165,23 @@ class LiquidRoundedRectangle extends LiquidShape {
   }
 
   @override
+  ShapeBorder scaleXY(double scaleX, double scaleY) {
+    return LiquidRoundedRectangle(
+      borderRadius: borderRadius.scaleXY(scaleX, scaleY),
+      side: side.scaleXY(scaleX, scaleY),
+    );
+  }
+
+  @override
   List<Object?> get props => [...super.props, borderRadius];
+}
+
+extension on Radius {
+  Radius scaleXY(double scaleX, double scaleY) =>
+      Radius.elliptical(x / scaleX, y / scaleY);
+}
+
+extension on BorderSide {
+  BorderSide scaleXY(double scaleX, double scaleY) =>
+      scale((scaleX + scaleY) / 2);
 }


### PR DESCRIPTION
- `Glassify` widget doesn't scale its child according to parent's constraints
- `LiquidGlass` does scale its "glass" effect, but doesn't scale background blur

To reproduce: run `example/lib/clock.dart`, and make the window narrower (see left screenshot below).
The pr fixes both issues (see the right screenshot)

<img width="300" height="628" alt="before" src="https://github.com/user-attachments/assets/9f9fada5-4357-4dd8-930e-4e6c65a8e157" /> <img width="300" height="628" alt="after" src="https://github.com/user-attachments/assets/e6330ab3-34b9-4cb4-9029-d2ee64768fa2" />


