### PR TITLE
fix: indicator getting stuck in example bottom bar

### DIFF
--- a/packages/liquid_glass_renderer/example/.metadata
+++ b/packages/liquid_glass_renderer/example/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "d693b4b9dbac2acd4477aea4555ca6dcbea44ba2"
+  revision: "9f455d2486bcb28cad87b062475f42edc959f636"
   channel: "stable"
 
 project_type: app
@@ -13,11 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: d693b4b9dbac2acd4477aea4555ca6dcbea44ba2
-      base_revision: d693b4b9dbac2acd4477aea4555ca6dcbea44ba2
+      create_revision: 9f455d2486bcb28cad87b062475f42edc959f636
+      base_revision: 9f455d2486bcb28cad87b062475f42edc959f636
+    - platform: android
+      create_revision: 9f455d2486bcb28cad87b062475f42edc959f636
+      base_revision: 9f455d2486bcb28cad87b062475f42edc959f636
     - platform: ios
-      create_revision: d693b4b9dbac2acd4477aea4555ca6dcbea44ba2
-      base_revision: d693b4b9dbac2acd4477aea4555ca6dcbea44ba2
+      create_revision: 9f455d2486bcb28cad87b062475f42edc959f636
+      base_revision: 9f455d2486bcb28cad87b062475f42edc959f636
+    - platform: linux
+      create_revision: 9f455d2486bcb28cad87b062475f42edc959f636
+      base_revision: 9f455d2486bcb28cad87b062475f42edc959f636
+    - platform: macos
+      create_revision: 9f455d2486bcb28cad87b062475f42edc959f636
+      base_revision: 9f455d2486bcb28cad87b062475f42edc959f636
+    - platform: web
+      create_revision: 9f455d2486bcb28cad87b062475f42edc959f636
+      base_revision: 9f455d2486bcb28cad87b062475f42edc959f636
+    - platform: windows
+      create_revision: 9f455d2486bcb28cad87b062475f42edc959f636
+      base_revision: 9f455d2486bcb28cad87b062475f42edc959f636
 
   # User provided section
 

--- a/packages/liquid_glass_renderer/example/lib/basic_app.dart
+++ b/packages/liquid_glass_renderer/example/lib/basic_app.dart
@@ -28,79 +28,90 @@ class BasicApp extends HookWidget {
 
     final light = AlwaysStoppedAnimation(pi / 4);
 
-    return GestureDetector(
-      onTap: () {
-        SettingsSheet(
-          blendNotifier: blendNotifier,
-          settingsNotifier: settingsNotifier,
-          lightAngleAnimation: light,
-        ).show(context);
-      },
-      child: CupertinoPageScaffold(
-        child: Stack(
-          children: [
-            CustomScrollView(
-              slivers: [
-                SliverGrid(
-                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
-                  ),
-                  delegate: SliverChildBuilderDelegate(
-                    (context, index) => Stack(
-                      children: [
-                        Positioned.fill(
-                          child: Image.network(
-                            fit: BoxFit.cover,
-                            'https://picsum.photos/500/500?random=$index',
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
+    return CupertinoPageScaffold(
+      child: Stack(
+        children: [
+          CustomScrollView(
+            slivers: [
+              SliverGrid(
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
                 ),
-              ],
-            ),
-            SafeArea(
-              child: Align(
-                alignment: Alignment.topLeft,
-                child: CupertinoSwitch(
-                  value: fake.value,
-                  onChanged: (v) => fake.value = v,
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) => Stack(
+                    children: [
+                      Positioned.fill(
+                        child: Image.network(
+                          fit: BoxFit.cover,
+                          'https://picsum.photos/500/500?random=$index',
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
+            ],
+          ),
+          SafeArea(
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: CupertinoSwitch(
+                value: fake.value,
+                onChanged: (v) => fake.value = v,
+              ),
             ),
-            Center(
-              child: ListenableBuilder(
-                listenable: Listenable.merge([
-                  settingsNotifier,
-                  light,
-                  blendNotifier,
-                ]),
-                builder: (context, child) {
-                  final settings = settingsNotifier.value.copyWith(
-                    glassColor: CupertinoTheme.of(
-                      context,
-                    ).barBackgroundColor.withValues(alpha: 0.2),
-                  );
-                  return LiquidGlassLayer(
-                    fake: fake.value,
-                    settings: settings.copyWith(lightAngle: light.value),
-                    child: LiquidGlassBlendGroup(
-                      blend: blendNotifier.value,
-                      child: Column(
-                        spacing: 16,
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Row(
-                            mainAxisSize: MainAxisSize.min,
-                            spacing: 16,
-                            children: [
-                              LiquidStretch(
-                                child: LiquidGlass.grouped(
-                                  shape: LiquidRoundedSuperellipse(
-                                    borderRadius: 20,
+          ),
+          Center(
+            child: ListenableBuilder(
+              listenable: Listenable.merge([
+                settingsNotifier,
+                light,
+                blendNotifier,
+              ]),
+              builder: (context, child) {
+                final settings = settingsNotifier.value.copyWith(
+                  glassColor: CupertinoTheme.of(
+                    context,
+                  ).barBackgroundColor.withValues(alpha: 0.2),
+                );
+                return LiquidGlassLayer(
+                  fake: fake.value,
+                  settings: settings.copyWith(lightAngle: light.value),
+                  child: LiquidGlassBlendGroup(
+                    blend: blendNotifier.value,
+                    child: Column(
+                      spacing: 16,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          spacing: 16,
+                          children: [
+                            LiquidStretch(
+                              child: LiquidGlass.grouped(
+                                shape: LiquidRoundedSuperellipse(
+                                  borderRadius: 20,
+                                ),
+                                child: GlassGlow(
+                                  child: SizedBox.square(
+                                    dimension: 100,
+                                    child: Center(
+                                      child: fake.value
+                                          ? Text('FAKE')
+                                          : Text('REAL'),
+                                    ),
                                   ),
-                                  child: GlassGlow(
+                                ),
+                              ),
+                            ),
+                            LiquidStretch(
+                              child: LiquidGlass.grouped(
+                                shape: LiquidRoundedSuperellipse(
+                                  borderRadius: 20,
+                                ),
+                                child: GlassGlow(
+                                  child: GestureDetector(
+                                    behavior: HitTestBehavior.opaque,
                                     child: SizedBox.square(
                                       dimension: 100,
                                       child: Center(
@@ -112,99 +123,103 @@ class BasicApp extends HookWidget {
                                   ),
                                 ),
                               ),
-                              LiquidStretch(
-                                child: LiquidGlass.grouped(
-                                  shape: LiquidRoundedSuperellipse(
-                                    borderRadius: 20,
-                                  ),
-                                  child: GlassGlow(
-                                    child: GestureDetector(
-                                      behavior: HitTestBehavior.opaque,
-                                      child: SizedBox.square(
-                                        dimension: 100,
-                                        child: Center(
-                                          child: fake.value
-                                              ? Text('FAKE')
-                                              : Text('REAL'),
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                          LiquidStretch(
-                            child: LiquidGlass.grouped(
-                              shape: LiquidRoundedSuperellipse(
-                                borderRadius: 9000,
-                              ),
-                              child: GlassGlow(
-                                child: GestureDetector(
-                                  behavior: HitTestBehavior.opaque,
-                                  child: SizedBox(
-                                    width: 400,
-                                    height: 64,
-                                    child: Center(
-                                      child: fake.value
-                                          ? Text('FAKE')
-                                          : Text('REAL'),
-                                    ),
+                            ),
+                          ],
+                        ),
+                        LiquidStretch(
+                          child: LiquidGlass.grouped(
+                            shape: LiquidRoundedSuperellipse(
+                              borderRadius: 9000,
+                            ),
+                            child: GlassGlow(
+                              child: GestureDetector(
+                                behavior: HitTestBehavior.opaque,
+                                child: SizedBox(
+                                  width: 400,
+                                  height: 64,
+                                  child: Center(
+                                    child: fake.value
+                                        ? Text('FAKE')
+                                        : Text('REAL'),
                                   ),
                                 ),
                               ),
                             ),
                           ),
-                        ],
-                      ),
+                        ),
+                        LiquidStretch(
+                          child: LiquidGlass.grouped(
+                            shape: LiquidRoundedSuperellipse(
+                              borderRadius: 9000,
+                            ),
+                            child: GlassGlow(
+                              child: GestureDetector(
+                                behavior: HitTestBehavior.opaque,
+                                onTap: () {
+                                  SettingsSheet(
+                                    blendNotifier: blendNotifier,
+                                    settingsNotifier: settingsNotifier,
+                                    lightAngleAnimation: light,
+                                  ).show(context);
+                                },
+                                child: SizedBox(
+                                  width: 400,
+                                  height: 64,
+                                  child: Center(child: Text('SETTINGS')),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
-                  );
+                  ),
+                );
+              },
+            ),
+          ),
+          SafeArea(
+            bottom: false,
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: LiquidGlassBottomBar(
+                fake: fake.value,
+                extraButton: LiquidGlassBottomBarExtraButton(
+                  icon: CupertinoIcons.add_circled,
+                  onTap: () {
+                    Navigator.of(context).push(
+                      CupertinoPageRoute(
+                        builder: (context) => CupertinoPageScaffold(
+                          child: SizedBox(),
+                          navigationBar: CupertinoNavigationBar.large(),
+                        ),
+                      ),
+                    );
+                  },
+                  label: '',
+                ),
+                tabs: [
+                  LiquidGlassBottomBarTab(
+                    label: 'Home',
+                    icon: CupertinoIcons.home,
+                  ),
+                  LiquidGlassBottomBarTab(
+                    label: 'Profile',
+                    icon: CupertinoIcons.person,
+                  ),
+                  LiquidGlassBottomBarTab(
+                    label: 'Settings',
+                    icon: CupertinoIcons.settings,
+                  ),
+                ],
+                selectedIndex: tab.value,
+                onTabSelected: (index) {
+                  tab.value = index;
                 },
               ),
             ),
-            SafeArea(
-              bottom: false,
-              child: Align(
-                alignment: Alignment.bottomCenter,
-                child: LiquidGlassBottomBar(
-                  fake: fake.value,
-                  extraButton: LiquidGlassBottomBarExtraButton(
-                    icon: CupertinoIcons.add_circled,
-                    onTap: () {
-                      Navigator.of(context).push(
-                        CupertinoPageRoute(
-                          builder: (context) => CupertinoPageScaffold(
-                            child: SizedBox(),
-                            navigationBar: CupertinoNavigationBar.large(),
-                          ),
-                        ),
-                      );
-                    },
-                    label: '',
-                  ),
-                  tabs: [
-                    LiquidGlassBottomBarTab(
-                      label: 'Home',
-                      icon: CupertinoIcons.home,
-                    ),
-                    LiquidGlassBottomBarTab(
-                      label: 'Profile',
-                      icon: CupertinoIcons.person,
-                    ),
-                    LiquidGlassBottomBarTab(
-                      label: 'Settings',
-                      icon: CupertinoIcons.settings,
-                    ),
-                  ],
-                  selectedIndex: tab.value,
-                  onTabSelected: (index) {
-                    tab.value = index;
-                  },
-                ),
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/packages/liquid_glass_renderer/example/lib/widgets/bottom_bar.dart
+++ b/packages/liquid_glass_renderer/example/lib/widgets/bottom_bar.dart
@@ -521,6 +521,7 @@ class _TabIndicatorState extends State<_TabIndicator>
       onHorizontalDragCancel: () => setState(() {
         _isDragging = false;
         _isDown = false;
+        xAlign = computeXAlignmentForTab(widget.tabIndex);
       }),
       child: VelocityMotionBuilder(
         converter: SingleMotionConverter(),

--- a/packages/liquid_glass_renderer/example/test/widget_test.dart
+++ b/packages/liquid_glass_renderer/example/test/widget_test.dart
@@ -1,0 +1,30 @@
+// This is a basic Flutter widget test.
+//
+// To perform an interaction with a widget in your test, use the WidgetTester
+// utility in the flutter_test package. For example, you can send tap and scroll
+// gestures. You can also use WidgetTester to find child widgets in the widget
+// tree, read text, and verify that the values of widget properties are correct.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liquid_glass_renderer_example/main.dart';
+
+void main() {
+  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(const MyApp());
+
+    // Verify that our counter starts at 0.
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
+
+    // Tap the '+' icon and trigger a frame.
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pump();
+
+    // Verify that our counter has incremented.
+    expect(find.text('0'), findsNothing);
+    expect(find.text('1'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Description

In the example project, the bottom nav bar had a bug where the tab indicator would get "stuck" between tabs or wherever the user clicked. This PR fixes #132 by updating the `xAlign` on drag cancel.

Additionally, the settings dialog now opens on a button click. Previously, it opened on tap anywhere on the screen and it was interfering with the gestures in the bottom nav bar.

## Checklist

- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes (none needed)
