### PR TITLE
Fix edge case for custom angle on android devices

### DIFF
--- a/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_arbitrary.frag
+++ b/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_arbitrary.frag
@@ -151,7 +151,8 @@ vec3 getReconstructedNormal(vec2 p, float thickness) {
     // At center, normals should point more upward (z approaches 1)
     // Adjust this exponent to decide how gradual this transition should be. Higher values are more abrupt
     float normalExponent = .2;
-    float normalZ = pow(edgeDistance, normalExponent);
+    // Prevent pow(0.0, >0) NaN on some Android/Impeller devices
+    float normalZ = pow(max(0.0001, edgeDistance), normalExponent);
     
     // Scale xy components to maintain unit length
     float xyScale = sqrt(max(0.0, 1.0 - normalZ * normalZ));

--- a/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_final_render.frag
+++ b/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_final_render.frag
@@ -101,14 +101,16 @@ void main() {
     float edgeFactor = 1.0 - smoothstep(0.0, edgeThreshold, normalizedHeight);
     
     if (edgeFactor > 0.01) {
-        vec2 normalXY = normalize(displacement);
+        float dispLen = length(displacement);
+        vec2 normalXY = dispLen > 0.0001 ? displacement / dispLen : vec2(0.0, 1.0);
         
         float mainLight = max(0.0, dot(normalXY, uLightDirection));
         float oppositeLight = max(0.0, dot(normalXY, -uLightDirection));
         
         float totalInfluence = mainLight + oppositeLight * 0.8;
         
-        float directional = pow(totalInfluence, 1.5) * uLightIntensity * 3.0;
+        // Prevent pow(0.0, >0) NaN on some Android/Impeller devices
+        float directional = pow(max(0.0001, totalInfluence), 1.5) * uLightIntensity * 3.0;
         float ambient = uAmbientStrength * 0.5;
         
         float brightness = (directional + ambient) * edgeFactor * thicknessScale * 0.8;

--- a/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_geometry_blended.frag
+++ b/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_geometry_blended.frag
@@ -45,7 +45,9 @@ void main() {
     float n_cos = max(uThickness + sd, 0.0) / uThickness;
     float n_sin = sqrt(max(0.0, 1.0 - n_cos * n_cos));
     
-    vec3 normal = normalize(vec3(dx * n_cos, dy * n_cos, n_sin));
+    vec3 rawNormal = vec3(dx * n_cos, dy * n_cos, n_sin);
+    float nLen = length(rawNormal);
+    vec3 normal = nLen > 0.0001 ? rawNormal / nLen : vec3(0.0, 0.0, 1.0);
     
     if (sd >= 0.0 || uThickness <= 0.0) {
         fragColor = vec4(0.0);

--- a/packages/liquid_glass_renderer/lib/assets/shaders/sdf.glsl
+++ b/packages/liquid_glass_renderer/lib/assets/shaders/sdf.glsl
@@ -112,5 +112,7 @@ vec3 getNormal(float sd, float thickness) {
     float n_cos = max(thickness + sd, 0.0) / thickness;
     float n_sin = sqrt(max(0.0, 1.0 - n_cos * n_cos));
     
-    return normalize(vec3(dx * n_cos, dy * n_cos, n_sin));
+    vec3 rawNormal = vec3(dx * n_cos, dy * n_cos, n_sin);
+    float nLen = length(rawNormal);
+    return nLen > 0.0001 ? rawNormal / nLen : vec3(0.0, 0.0, 1.0);
 }


### PR DESCRIPTION
With:
```dart
LiquidGlassSettings(
    thickness: 40,
    blur: 3,
    glassColor: context.colors.glassColor,
    chromaticAberration: 0.1,
    lightAngle: -math.pi / 4, // <- causes problem
    ambientStrength: 0.2,
    lightIntensity: 0.6,
)
```
I was getting black pixels on edge of glass on Android devices (iOS works fine):
<img width="605" height="598" alt="image" src="https://github.com/user-attachments/assets/73b09ef8-9da4-4ba8-9448-3e3eb9e9eab1" />

Now we guard pow() and normalize() against zero inputs that produce NaN.
