### PR TITLE
fix: guard against NaN/Infinity crash in _buildGeometryImage (#131)

### DIFF
--- a/packages/liquid_glass_renderer/lib/src/rendering/liquid_glass_render_object.dart
+++ b/packages/liquid_glass_renderer/lib/src/rendering/liquid_glass_render_object.dart
@@ -194,6 +194,12 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
         boundingBox,
       );
 
+      if (image == null) {
+        // Degenerate size — skip glass rendering, paint children normally.
+        super.paint(context, offset);
+        return;
+      }
+
       _geometryImage = image;
       _geometryMatteBounds = matteBounds;
     }
@@ -300,7 +306,7 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
   @protected
   bool needsGeometryUpdate = true;
 
-  (ui.Image, Rect) _buildGeometryImage(
+  (ui.Image?, Rect) _buildGeometryImage(
     List<(RenderLiquidGlassGeometry, GeometryCache, Matrix4)> geometries,
     Rect bounds,
   ) {
@@ -310,6 +316,19 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
     ).snapToPixels(devicePixelRatio);
 
     final size = boundsInMatteSpace.size * devicePixelRatio;
+
+    // Guard against degenerate sizes that cause toInt() to throw
+    // "Unsupported operation: Infinity or NaN toInt" (#131).
+    // This can happen during layout transitions when the render object
+    // temporarily receives zero or invalid constraints.
+    if (size.width <= 0 ||
+        size.height <= 0 ||
+        !size.width.isFinite ||
+        !size.height.isFinite) {
+      return (null, boundsInMatteSpace);
+    }
+    final w = size.width.ceil();
+    final h = size.height.ceil();
 
     final buffer = StringBuffer('$hashCode Built geometry image with '
         '${geometries.length} shapes at size ${size.width}x${size.height}:\n');
@@ -351,10 +370,7 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
     }
 
     final picture = recorder.endRecording();
-    final image = picture.toImageSync(
-      size.width.ceil(),
-      size.height.ceil(),
-    );
+    final image = picture.toImageSync(w, h);
 
     logger.fine(buffer.toString());
     picture.dispose();


### PR DESCRIPTION
## Summary

Fixes #131 — `Unsupported operation: Infinity or NaN toInt` crash in `_buildGeometryImage`.

### Root Cause

When `LiquidGlassLayer` receives degenerate constraints (zero or NaN dimensions) during layout transitions — e.g., `floatingActionButton` slot changes or animated show/hide — `boundsInMatteSpace.size * devicePixelRatio` produces invalid values. Calling `.ceil()` on NaN/Infinity throws.

### Changes

- **Guard check** before `.ceil()`: validates `size.width` and `size.height` are positive and finite
- **Nullable return**: `_buildGeometryImage` returns `(null, bounds)` for degenerate sizes
- **Graceful fallback**: caller falls back to `super.paint()` when image is null, rendering children normally instead of crashing

### Before / After

| Scenario | Before | After |
|----------|--------|-------|
| FAB slot transition (0-size frame) | 💥 Crash | ✅ Graceful fallback |
| Normal rendering | ✅ Works | ✅ Works (no behavior change) |

### Testing

Tested by wrapping `LiquidGlassLayer` in a `SizedBox` with animated constraints that briefly pass through `0×0`. Previously crashed, now renders gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)