### PR TITLE
fix: stop double-flipping OpenGLES texture Y on Flutter 3.44+

### DIFF
--- a/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_arbitrary.frag
+++ b/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_arbitrary.frag
@@ -198,8 +198,11 @@ void main() {
     vec4 blurred = texture(uForegroundBlurredTexture, layerUV);
     float sd = approximateSDF(blurred.a, uThickness);
     
-#ifdef IMPELLER_TARGET_OPENGLES
-    // Convert flipped layerUV back to layer-local coordinates for normal calculation
+#if defined(IMPELLER_TARGET_OPENGLES) && !defined(IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED)
+    // Convert flipped layerUV back to layer-local coordinates for normal calculation.
+    // Only applies on engines that predate Flutter 3.44's OpenGLES coordinate
+    // normalization, matching the condition in computeY() (shared.glsl) that
+    // produced this flipped layerUV in the first place.
     transformedCoord.xy = layerUV * uForegroundSize;
 #endif
     vec3 normal = getNormal(transformedCoord.xy, uThickness);

--- a/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_filter.frag
+++ b/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_filter.frag
@@ -45,7 +45,12 @@ void main() {
      
     // We invert screenUV Y on OpenGL to sample the textures correctly
     // fragCoord stays the same so shape positions are correct.
-    #ifdef IMPELLER_TARGET_OPENGLES
+    //
+    // Flutter 3.44+ normalizes the OpenGLES texture coordinate system to match
+    // other backends (the engine flips it for us), so the extra flip below is
+    // only still needed on engines that predate that change.
+    // See https://groups.google.com/g/flutter-announce/c/WQHn5LvciKk
+    #if defined(IMPELLER_TARGET_OPENGLES) && !defined(IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED)
         vec2 screenUV = vec2(fragCoord.x / uSize.x, 1.0 - (fragCoord.y / uSize.y));
     #else
         vec2 screenUV = vec2(fragCoord.x / uSize.x, fragCoord.y / uSize.y);

--- a/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_final_render.frag
+++ b/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_final_render.frag
@@ -39,14 +39,18 @@ void main() {
     // So we need to scale by devicePixelRatio to work in physical pixel space
     vec2 fragCoord = FlutterFragCoord().xy;
     
-    vec2 screenUV = vec2(fragCoord.x / uSize.x, fragCoord.y / uSize.y);        
-        
-    #ifdef IMPELLER_TARGET_OPENGLES
+    vec2 screenUV = vec2(fragCoord.x / uSize.x, fragCoord.y / uSize.y);
+
+    // Flutter 3.44+ normalizes the OpenGLES texture coordinate system to match
+    // other backends (the engine flips it for us), so the extra flip below is
+    // only still needed on engines that predate that change.
+    // See https://groups.google.com/g/flutter-announce/c/WQHn5LvciKk
+    #if defined(IMPELLER_TARGET_OPENGLES) && !defined(IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED)
         screenUV.y = 1.0 - screenUV.y;
     #endif
 
     vec2 geometryUV = (fragCoord - uGeometryOffset) / uGeometrySize;
-    #ifdef IMPELLER_TARGET_OPENGLES
+    #if defined(IMPELLER_TARGET_OPENGLES) && !defined(IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED)
         geometryUV.y = 1.0 - geometryUV.y;
     #endif
 

--- a/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_geometry_blended.frag
+++ b/packages/liquid_glass_renderer/lib/assets/shaders/liquid_glass_geometry_blended.frag
@@ -25,7 +25,11 @@ layout(location = 0) out vec4 fragColor;
 void main() {
     vec2 fragCoord = FlutterFragCoord().xy;
     
-    #ifdef IMPELLER_TARGET_OPENGLES
+    // Flutter 3.44+ normalizes the OpenGLES texture coordinate system to match
+    // other backends (the engine flips it for us), so the extra flip below is
+    // only still needed on engines that predate that change.
+    // See https://groups.google.com/g/flutter-announce/c/WQHn5LvciKk
+    #if defined(IMPELLER_TARGET_OPENGLES) && !defined(IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED)
         vec2 screenUV = vec2(fragCoord.x / uSize.x, 1.0 - (fragCoord.y / uSize.y));
     #else
         vec2 screenUV = vec2(fragCoord.x / uSize.x, fragCoord.y / uSize.y);

--- a/packages/liquid_glass_renderer/lib/assets/shaders/render.glsl
+++ b/packages/liquid_glass_renderer/lib/assets/shaders/render.glsl
@@ -10,9 +10,12 @@ mat2 rotate2d(float angle) {
     return mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
 }
 
-// Compute Y coordinate reversing it for OpenGL backend
+// Compute Y coordinate, reversing it for OpenGL backends that predate
+// Flutter 3.44's OpenGLES texture coordinate normalization (the engine flips
+// it for us from that version on).
+// See https://groups.google.com/g/flutter-announce/c/WQHn5LvciKk
 float computeY(float coordY, vec2 size) {
-    #ifdef IMPELLER_TARGET_OPENGLES
+    #if defined(IMPELLER_TARGET_OPENGLES) && !defined(IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED)
         return 1.0 - (coordY / size.y);
     #else
         return coordY / size.y;

--- a/packages/liquid_glass_renderer/lib/assets/shaders/shared.glsl
+++ b/packages/liquid_glass_renderer/lib/assets/shaders/shared.glsl
@@ -10,9 +10,12 @@ mat2 rotate2d(float angle) {
     return mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
 }
 
-// Compute Y coordinate reversing it for OpenGL backend
+// Compute Y coordinate, reversing it for OpenGL backends that predate
+// Flutter 3.44's OpenGLES texture coordinate normalization (the engine flips
+// it for us from that version on).
+// See https://groups.google.com/g/flutter-announce/c/WQHn5LvciKk
 float computeY(float coordY, vec2 size) {
-    #ifdef IMPELLER_TARGET_OPENGLES
+    #if defined(IMPELLER_TARGET_OPENGLES) && !defined(IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED)
         return 1.0 - (coordY / size.y);
     #else
         return coordY / size.y;


### PR DESCRIPTION
## What's broken

All liquid glass shaders manually flip the Y coordinate when sampling background/geometry textures, gated behind `#ifdef IMPELLER_TARGET_OPENGLES`:

```glsl
#ifdef IMPELLER_TARGET_OPENGLES
    screenUV.y = 1.0 - screenUV.y;
#endif
```

That flip existed to compensate for Impeller's OpenGLES (Android) backend uploading textures bottom-up.

Flutter normalized this at the engine level starting with the first stable release after 3.44.0 (3.47.0) — see the [breaking-change announcement](https://groups.google.com/g/flutter-announce/c/WQHn5LvciKk). From that version on, the vertex shader already flips OpenGLES texture coordinates to match Metal/Vulkan, so a shader that still does its own manual flip ends up **double-flipping** on Android.

### Symptom

On Android with Flutter 3.47+, `LiquidGlass`/`LiquidGlassLayer` widgets sample content from the vertically-mirrored position on screen instead of what's actually behind them. Concretely: a glass bottom nav bar shows content from near the *top* of the screen (e.g. a header/logo) inside the pill, instead of refracting what's directly behind it. iOS (Metal) is unaffected since it was never inside this `#ifdef` branch.

Repro: `liquid_glass_renderer: 0.2.0-dev.4` + Flutter 3.47.0, any `LiquidGlassLayer` positioned away from the top of the screen, on a real Android device or emulator using the Impeller OpenGLES backend.

## The fix

Flutter's engine team shipped a transition macro for exactly this situation, `IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED`, which is defined once the engine already does the flip itself. Gating the manual flip on `defined(IMPELLER_TARGET_OPENGLES) && !defined(IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED)` keeps these shaders correct on both pre- and post-3.44 engines, with no need to bump this package's Flutter SDK floor (currently `>=3.32.4`).

Applied the same fix everywhere this pattern appears:
- `liquid_glass_final_render.frag` (`screenUV`, `geometryUV`) — the shader `LiquidGlassLayer` renders through, so this is the one causing the bottom-bar symptom above
- `liquid_glass_geometry_blended.frag` (`screenUV`)
- `liquid_glass_filter.frag` (`screenUV`)
- `shared.glsl` / `render.glsl` (`computeY()`, included by `liquid_glass_arbitrary.frag` and `liquid_glass_final_render.frag` respectively)
- `liquid_glass_arbitrary.frag` — a second, separate compensating block that reconstructs `transformedCoord.xy` from the flipped `layerUV` for normal calculation; updated to the same condition so it stays consistent with `computeY()`'s new behavior

## Testing

I don't have a Mac available to run the existing golden-image test suite (`test/src/goldens/...`) or verify on an iOS/Metal target, so I'd appreciate a maintainer re-running goldens on both Impeller backends before merging. Verified manually on a physical Android device (Impeller OpenGLES, Flutter 3.47.0) that a `LiquidGlassLayer`-based bottom nav bar refracts the content actually behind it instead of content from the top of the screen, both before (broken) and after (fixed) this change.